### PR TITLE
handle missing cache tarballs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 
 start=`date +%s`
 
-curl -s $cache_get_url | tar -C $CACHE_DIR -zxf -
+curl -s --fail $cache_get_url | tar -C $CACHE_DIR -zxf -
 
 end=`date +%s`
 echo "(took $((end-start))s)"


### PR DESCRIPTION
If there is no `format-staging` cache tarball to download, the buildpack fails and blocks the whole build.

```
-----> Shared Build Cache app detected
Restoring shared build cache from app [format-staging]...
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
 !     Push rejected, failed to compile Shared Build Cache app.
 !     Push failed
```

Use `curl --fail`: "Fail fast with no output at all on server errors" so we don't try to pipe an error message to `tar`.