### PR TITLE
ignore tar errors

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 
 start=`date +%s`
 
-curl -s --fail $cache_get_url | tar -C $CACHE_DIR -zxf -
+curl -sSf $cache_get_url | tar -C $CACHE_DIR -zxf - || true
 
 end=`date +%s`
 echo "(took $((end-start))s)"


### PR DESCRIPTION
Handle tar errors (unlike #2) for missing cache tarballs.

This reports the error but returns an exit code of 0, so the script doesn't fail.

```
curl: (22) The requested URL returned error: 404

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```